### PR TITLE
Use a view for active boulders

### DIFF
--- a/api/src/Queries.hs
+++ b/api/src/Queries.hs
@@ -2,7 +2,6 @@
 
 module Queries
     ( mapId
-    , isActive
     , isOwnBoulder
     , isSetter
     , hasAccess
@@ -29,12 +28,6 @@ isSetter :: R.Exp R.Object -> R.Exp Bool
 isSetter = \x -> R.Ne
     (R.GetField "role" x :: R.Exp Text)
     ("user" :: R.Exp Text)
-
--- all still active boulders (without a removed date)
-isActive :: R.Exp R.Object -> R.Exp Bool
-isActive = \x -> R.Eq
-    (R.GetField "removed" x :: R.Exp Double)
-    (0 :: R.Exp Double)
 
 -- FIXME: we should check if the setter is in the list of setters
 --        setter is a list of setterIds

--- a/api/src/Routes.hs
+++ b/api/src/Routes.hs
@@ -92,8 +92,7 @@ serveLocalAPI aversH =
             runQueryCollect $
                 R.Map mapId $
                 R.OrderBy [R.Descending "setDate"] $
-                R.Filter isActive $
-                viewTable bouldersView
+                viewTable activeBouldersView
 
         pure $ map ObjId $ V.toList boulders
 

--- a/api/src/Storage/Objects/Boulder.hs
+++ b/api/src/Storage/Objects/Boulder.hs
@@ -4,6 +4,7 @@ module Storage.Objects.Boulder
     ( module Storage.Objects.Boulder.Types
     , boulderObjectType
     , bouldersView
+    , activeBouldersView
     ) where
 
 
@@ -17,6 +18,7 @@ mkObjId len = ObjId <$> liftIO (newId len)
 boulderViews :: [SomeView Boulder]
 boulderViews =
     [ SomeView bouldersView
+    , SomeView activeBouldersView
     ]
 
 boulderObjectType :: ObjectType Boulder
@@ -31,5 +33,14 @@ bouldersView = View
     { viewName              = "boulders"
     , viewParser            = parseDatum
     , viewObjectTransformer = return . Just
+    , viewIndices           = []
+    }
+
+activeBouldersView :: View Boulder Boulder
+activeBouldersView = View
+    { viewName              = "activeBoulders"
+    , viewParser            = parseDatum
+    , viewObjectTransformer = \boulder ->
+        if boulderRemoved boulder > 0 then pure Nothing else pure (Just boulder)
     , viewIndices           = []
     }


### PR DESCRIPTION
Can't test it right now but something like this should improve performance by keeping a separate table with only the active boulders, instead of filtering all boulders each time the `activeBoulders` collection is requested.