### PR TITLE
Adding simple planning tool

### DIFF
--- a/api/src/Routes.hs
+++ b/api/src/Routes.hs
@@ -139,6 +139,10 @@ type LocalAPI
     :<|> "collection" :> "activeBoulders"
       :> Get '[JSON] [ObjId]
 
+    -- serve a list of all draft bouldersIds in the gym
+    :<|> "collection" :> "draftBoulders"
+      :> Get '[JSON] [ObjId]
+
     -- serve a list of boulderIds that are owned/authored by the user
     :<|> "collection" :> "ownBoulders"
       :> Credentials
@@ -178,6 +182,7 @@ serveLocalAPI pc aversH =
          serveRevision
     :<|> serveHealthz
     :<|> serveActiveBouldersCollection
+    :<|> serveDraftBouldersCollection
     :<|> serveOwnBouldersCollection
     :<|> serveAccounts
     :<|> serveAdminAccounts
@@ -226,6 +231,15 @@ serveLocalAPI pc aversH =
                 R.Map mapId $
                 R.OrderBy [R.Descending "setDate"] $
                 viewTable activeBouldersView
+
+        pure $ map ObjId $ V.toList boulders
+
+    serveDraftBouldersCollection = do
+        boulders <- reqAvers2 aversH $ do
+            runQueryCollect $
+                R.Map mapId $
+                R.OrderBy [R.Descending "setDate"] $
+                viewTable draftBouldersView
 
         pure $ map ObjId $ V.toList boulders
 

--- a/api/src/Storage/Objects/Boulder.hs
+++ b/api/src/Storage/Objects/Boulder.hs
@@ -5,6 +5,7 @@ module Storage.Objects.Boulder
     , boulderObjectType
     , bouldersView
     , activeBouldersView
+    , draftBouldersView
     ) where
 
 
@@ -19,6 +20,7 @@ boulderViews :: [SomeView Boulder]
 boulderViews =
     [ SomeView bouldersView
     , SomeView activeBouldersView
+    , SomeView draftBouldersView
     ]
 
 boulderObjectType :: ObjectType Boulder
@@ -32,7 +34,8 @@ bouldersView :: View Boulder Boulder
 bouldersView = View
     { viewName              = "boulders"
     , viewParser            = parseDatum
-    , viewObjectTransformer = return . Just
+    , viewObjectTransformer = \boulder ->
+        if boulderIsDraft boulder == 0 then pure (Just boulder) else pure Nothing
     , viewIndices           = []
     }
 
@@ -41,6 +44,15 @@ activeBouldersView = View
     { viewName              = "activeBoulders"
     , viewParser            = parseDatum
     , viewObjectTransformer = \boulder ->
-        if boulderRemoved boulder > 0 then pure Nothing else pure (Just boulder)
+        if (boulderIsDraft boulder == 0) && (boulderRemoved boulder == 0) then pure (Just boulder) else pure Nothing
+    , viewIndices           = []
+    }
+
+draftBouldersView :: View Boulder Boulder
+draftBouldersView = View
+    { viewName              = "draftBoulders"
+    , viewParser            = parseDatum
+    , viewObjectTransformer = \boulder ->
+        if boulderIsDraft boulder > 0 then pure (Just boulder) else pure Nothing
     , viewIndices           = []
     }

--- a/api/src/Storage/Objects/Boulder/Types.hs
+++ b/api/src/Storage/Objects/Boulder/Types.hs
@@ -19,6 +19,7 @@ data Boulder = Boulder
     , boulderGradeNr    :: Int
     , boulderSetDate    :: Int                  -- Data.Time.Calendar.Day
     , boulderRemoved    :: Int                  -- Date.Time.Calendar.Day
+    , boulderIsDraft    :: Int 
     , boulderName       :: Maybe Text
     }
     deriving (Show, Generic)

--- a/client/pages/admin/planned.tsx
+++ b/client/pages/admin/planned.tsx
@@ -1,0 +1,95 @@
+import * as Avers from "avers";
+import * as React from "react";
+import styled from "styled-components";
+import Link from "next/link";
+
+import { useEnv } from "../../src/env";
+import * as Storage from "../../src/storage";
+import { boulderCompare, prettyPrintSector, publicProfile } from "../../src/storage";
+import { draftBoulders, resetBoulderCollections } from "../../src/actions";
+
+import { Site } from "../../src/Views/Components/Site";
+import { BoulderId24 } from "../../src/Views/Components/BoulderId";
+import * as MUI from "@material-ui/core";
+
+export default () => {
+  const { app } = useEnv();
+
+  const setterName = (accountId): string => {
+    let profile = Avers.staticValue(app.data.aversH, publicProfile(app.data.aversH, accountId)).get(undefined);
+    if (profile && profile.name !== "") {
+      return profile.name;
+    } else {
+      return accountId.slice(0, 5);
+    }
+  };
+
+  const fulfill = (boulderE: Avers.Editable<Storage.Boulder>) => {
+    const now = Date.now();
+    boulderE.content.setDate = now.valueOf();
+    // XXX: workaround (change listener removed after first change)
+    boulderE = Avers.lookupEditable<Storage.Boulder>(app.data.aversH, boulderE.objectId).get(undefined)!;
+    boulderE.content.isDraft = 0;
+    resetBoulderCollections(app);
+  };
+
+  return (
+    <Site>
+      <Root>
+        <table>
+          <thead>
+            <tr>
+              <th style={{ width: 100 }}>Boulder</th>
+              <th style={{ width: 100 }}>Sektor</th>
+              <th style={{ width: 100 }}>Setter</th>
+              <th style={{ width: 100 }}>Done</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr style={{ height: "20px" }}>
+              <td colSpan="4"></td>
+            </tr>
+            {draftBoulders(app)
+              .sort((a, b) => boulderCompare(a.content, b.content))
+              .map((boulderE) => {
+                return (
+                  <tr key={boulderE.objectId}>
+                    <td>
+                      <Link href={{ pathname: "/boulder", query: { id: boulderE.objectId } }}>
+                        <BoulderId24 grade={boulderE.content.grade}></BoulderId24>
+                      </Link>
+                    </td>
+                    <td>{prettyPrintSector(boulderE.content.sector)}</td>
+                    <td>{setterName(boulderE.content.setter)}</td>
+                    <td>
+                      <MUI.Button variant="contained" color="primary" onClick={() => fulfill(boulderE)}>
+                        Erledigt
+                      </MUI.Button>
+                    </td>
+                  </tr>
+                );
+              })}
+          </tbody>
+        </table>
+      </Root>
+    </Site>
+  );
+};
+
+const Root = styled.div`
+  margin: 30px 24px;
+
+  table {
+    width: 80%;
+    margin-left: auto;
+    margin-right: auto;
+
+    th {
+      text-align: left;
+    }
+
+    td {
+      border-bottom: 1px solid #ddd;
+    }
+  }
+`;

--- a/client/pages/auftraege.tsx
+++ b/client/pages/auftraege.tsx
@@ -1,0 +1,86 @@
+import * as Avers from "avers";
+import * as React from "react";
+import styled from "styled-components";
+import Link from "next/link";
+
+import { useEnv } from "../src/env";
+import * as Storage from "../src/storage";
+import { boulderCompare, prettyPrintSector } from "../src/storage";
+import { draftBoulders, resetBoulderCollections } from "../src/actions";
+
+import { Site } from "../src/Views/Components/Site";
+import { BoulderId24 } from "../src/Views/Components/BoulderId";
+import * as MUI from "@material-ui/core";
+
+export default () => {
+  const { app } = useEnv();
+
+  const fulfill = (boulderE: Avers.Editable<Storage.Boulder>) => {
+    const now = Date.now();
+    boulderE.content.setDate = now.valueOf();
+    // XXX: workaround (change listener removed after first change)
+    boulderE = Avers.lookupEditable<Storage.Boulder>(app.data.aversH, boulderE.objectId).get(undefined)!;
+    boulderE.content.isDraft = 0;
+    resetBoulderCollections(app);
+  };
+
+  return (
+    <Site>
+      <Root>
+        <table>
+          <thead>
+            <tr>
+              <th style={{ width: 100 }}>Boulder</th>
+              <th style={{ width: 100 }}>Sektor</th>
+              <th style={{ width: 100 }}>Done</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr style={{ height: "20px" }}>
+              <td colSpan="4"></td>
+            </tr>
+            {draftBoulders(app)
+              .sort((a, b) => boulderCompare(a.content, b.content))
+              .map((boulderE) => {
+                if (app.data.session.objId && boulderE.content.setter.includes(app.data.session.objId)) {
+                  return (
+                    <tr key={boulderE.objectId}>
+                      <td>
+                        <Link href={{ pathname: "/boulder", query: { id: boulderE.objectId } }}>
+                          <BoulderId24 grade={boulderE.content.grade}></BoulderId24>
+                        </Link>
+                      </td>
+                      <td>{prettyPrintSector(boulderE.content.sector)}</td>
+                      <td>
+                        <MUI.Button variant="contained" color="primary" onClick={() => fulfill(boulderE)}>
+                          Erledigt
+                        </MUI.Button>
+                      </td>
+                    </tr>
+                  );
+                }
+              })}
+          </tbody>
+        </table>
+      </Root>
+    </Site>
+  );
+};
+
+const Root = styled.div`
+  margin: 30px 24px;
+
+  table {
+    width: 80%;
+    margin-left: auto;
+    margin-right: auto;
+
+    th {
+      text-align: left;
+    }
+
+    td {
+      border-bottom: 1px solid #ddd;
+    }
+  }
+`;

--- a/client/pages/boulder.tsx
+++ b/client/pages/boulder.tsx
@@ -42,6 +42,17 @@ function BoulderDetailsEditor({ app, boulderE }: { app: App; boulderE: Avers.Edi
   function setRemoved() {
     changeRemovedDate(Date.now());
   }
+  
+  function toggleDraft() {
+    if (boulder.isDraft == 1) {
+      const now = Date.now();
+      // boulder.setDate = now.valueOf();
+      boulder.isDraft = 0;
+    } else {
+      boulder.isDraft = 1;
+    }
+    resetBoulderCollections(app);
+  }
 
   function clone() {
     cloneBoulder(app, boulderE);
@@ -106,6 +117,23 @@ function BoulderDetailsEditor({ app, boulderE }: { app: App; boulderE: Avers.Edi
 
       <Section>Utilities</Section>
         <DangerButton onClick={clone}>Add another boulder like this</DangerButton>
+
+      <Section>Planing</Section>
+      {(() => {
+        if (boulder.isDraft > 0) {
+          return (
+            <div>
+              <DangerButton onClick={toggleDraft}>Marked as Draft -> Done</DangerButton>
+            </div>
+          );
+        } else {
+          return (
+            <div>
+              <DangerButton onClick={toggleDraft}>Set as draft Boulder</DangerButton>
+            </div>
+          );
+        }
+      })()}
 
       <Section>Danger Zone</Section>
       {(() => {

--- a/client/src/Components/AdminBar.tsx
+++ b/client/src/Components/AdminBar.tsx
@@ -12,6 +12,9 @@ export const AdminBar = () => (
     <Link href="/admin/accounts">
       <a>Accounts</a>
     </Link>
+    <Link href="/admin/planned">
+      <a>Planned</a>
+    </Link>
     <Link href="/admin/boulders">
       <a>Boulders</a>
     </Link>

--- a/client/src/Components/Header/Header.tsx
+++ b/client/src/Components/Header/Header.tsx
@@ -105,6 +105,10 @@ export const Header = React.memo(() => {
                     if (app.data.session.objId) {
                       return (
                         <>
+                          <Link href="/auftraege" passHref>
+                            <SecondaryNavigationLink>Auftraege</SecondaryNavigationLink>
+                          </Link>
+
                           <Link href="/settings" passHref>
                             <SecondaryNavigationLink>Settings</SecondaryNavigationLink>
                           </Link>

--- a/client/src/actions.ts
+++ b/client/src/actions.ts
@@ -12,6 +12,7 @@ export const resetBoulderCollections = (app: App): void => {
   Avers.resetObjectCollection(app.data.bouldersCollection);
   Avers.resetObjectCollection(app.data.ownedBoulderCollection);
   Avers.resetObjectCollection(app.data.activeBouldersCollection);
+  Avers.resetObjectCollection(app.data.draftBouldersCollection);
 };
 
 export function createBoulder(app: App) {
@@ -61,7 +62,14 @@ export function activeBoulders(app: App): Avers.Editable<Storage.Boulder>[] {
   return app.data.activeBouldersCollection.ids
     .get<string[]>([])
     .map((boulderId) => Avers.lookupEditable<Storage.Boulder>(app.data.aversH, boulderId).get(null))
-    .filter((x) => x !== null && !x.content.removed) as any;
+    .filter((x) => x !== null && !x.content.removed && x.content.isDraft == 0) as any;
+}
+
+export function draftBoulders(app: App): Avers.Editable<Storage.Boulder>[] {
+  return app.data.draftBouldersCollection.ids
+    .get<string[]>([])
+    .map((boulderId) => Avers.lookupEditable<Storage.Boulder>(app.data.aversH, boulderId).get(null))
+    .filter((x) => x !== null && !x.content.removed && x.content.isDraft !== 0) as any;
 }
 
 export function removeBoulders(app: App, boulders: Avers.Editable<Storage.Boulder>[]) {

--- a/client/src/app.ts
+++ b/client/src/app.ts
@@ -30,6 +30,7 @@ export class Data {
 
   public bouldersCollection: Avers.ObjectCollection;
   public activeBouldersCollection: Avers.ObjectCollection;
+  public draftBouldersCollection: Avers.ObjectCollection;
   public ownedBoulderCollection: Avers.ObjectCollection;
 
   constructor(public aversH: Avers.Handle) {
@@ -47,6 +48,9 @@ export class Data {
 
     // Collection of all boulders currently active in the gym
     this.activeBouldersCollection = new Avers.ObjectCollection(aversH, "activeBoulders");
+
+    // Collection of all planned draft boulders
+    this.draftBouldersCollection = new Avers.ObjectCollection(aversH, "draftBoulders");
 
     // Collection of boulders for a given user (setter/admin)
     this.ownedBoulderCollection = new Avers.ObjectCollection(aversH, "ownedBoulders");

--- a/client/src/storage.ts
+++ b/client/src/storage.ts
@@ -18,6 +18,7 @@ export class Boulder {
   gradeNr!: number;
   setDate!: number;
   removed!: number;
+  isDraft!: number;
   name!: string;
 }
 
@@ -27,6 +28,7 @@ Avers.definePrimitive(Boulder, "grade", "yellow");
 Avers.definePrimitive(Boulder, "gradeNr", 0);
 Avers.definePrimitive(Boulder, "setDate", 0);
 Avers.definePrimitive(Boulder, "removed", 0);
+Avers.definePrimitive(Boulder, "isDraft", 0);
 Avers.definePrimitive(Boulder, "name", "");
 
 export const roles: string[] = ["user", "setter", "admin"];


### PR DESCRIPTION
First steps towards adding a planning tool:

- adding backend code to support "draft" boulders.
- adding UI to flag a boulder as "draft" and views for admins (all draft boulders) + a view for setters (commissions).